### PR TITLE
Improves error handling and allows configuring maximum request size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "esetres"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "axum",
  "bcrypt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esetres"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["Aidan Bleser"]
 readme = "README.md"

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -19,7 +19,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         tokens_map.insert(token.name.clone(), token);
     }
 
-    let app = router::create(tokens_map, AppState { config });
+    let app = router::create(tokens_map, &config.clone(), AppState { config });
 
     let listener = tokio::net::TcpListener::bind(&address).await?;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,13 +1,13 @@
 use std::env;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Object {
     pub root_directory: String,
-    pub mime_types: MimeTypes,
     pub token_secret: String,
     pub ip: String,
     pub port: u16,
     pub https: bool,
+    pub max_size_mb: usize,
 }
 
 impl Object {
@@ -40,8 +40,9 @@ pub fn get() -> Object {
             .parse()
             .unwrap(),
         root_directory: "./buckets".to_string(),
-        mime_types: MimeTypes {
-            local_path: "./mime-db.json".to_string(),
-        },
+        max_size_mb: env::var("MAX_SIZE_MB")
+            .unwrap_or("2".to_string())
+            .parse()
+            .unwrap(),
     }
 }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -4,9 +4,7 @@ use crate::{
     jwt::validate,
 };
 use axum::{
-    http::HeaderMap,
-    routing::{get, post, put},
-    Extension, Router,
+    extract::DefaultBodyLimit, http::HeaderMap, routing::{get, post, put}, Extension, Router
 };
 use bcrypt::verify;
 use std::{collections::HashMap, sync::Arc};
@@ -28,7 +26,7 @@ pub struct AppState {
     pub config: config::Object
 }
 
-pub fn create(tokens: HashMap<String, Token>, app_state: AppState) -> Router {
+pub fn create(tokens: HashMap<String, Token>, config: &config::Object, app_state: AppState) -> Router {
     /* State initialization */
 
     let state = Arc::new(app_state);
@@ -73,7 +71,8 @@ pub fn create(tokens: HashMap<String, Token>, app_state: AppState) -> Router {
         .layer(
             ServiceBuilder::new()
                 .layer(cors)
-                .layer(Extension(token_cache)),
+                .layer(Extension(token_cache))
+                .layer(DefaultBodyLimit::max(config.max_size_mb * 1024 * 1024)),
         )
 }
 


### PR DESCRIPTION
Adds `MAX_SIZE_MB` environment variable to allow you to configure the maximum size of a request.

Also improves error handling for upload method.

Bumping this a major it should have been for the last release so I apologize to anyone I broke doing that.